### PR TITLE
switch data type Nothing to value

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -33,11 +33,11 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     binbounds::Dict{VI,BOUNDS} # only for binary variables
     params::Dict{String,Any}
     start::Dict{VI,Float64} # can be partial
-    moi_separator # ::Union{CutCbSeparator, Nothing}
+    moi_separator::Any #Union{CutCbSeparator, Nothing}
 
     function Optimizer(; kwargs...)
         o = new(ManagedSCIP(), PtrMap(), ConsTypeMap(), Dict(), Dict(), Dict(),
-                Nothing)
+                nothing)
 
         # Set all parameters given as keyword arguments, replacing the
         # delimiter, since "/" is used by all SCIP parameters, but is not
@@ -152,7 +152,7 @@ function MOI.get(o::Optimizer, ::MOI.TimeLimitSec)
 end
 
 function MOI.set(o::Optimizer, ::MOI.TimeLimitSec, value)
-    if value == nothing
+    if value === nothing
         MOI.set(o, MOI.RawParameter("limits/time"), SCIPinfinity(o))
     else
         MOI.set(o, MOI.RawParameter("limits/time"), value)

--- a/src/MOI_wrapper/linear_constraints.jl
+++ b/src/MOI_wrapper/linear_constraints.jl
@@ -13,8 +13,8 @@ function MOI.add_constraint(o::Optimizer, func::SAF, set::S) where {S <: BOUNDS}
     coefs = [t.coefficient for t in func.terms]
 
     lhs, rhs = bounds(set)
-    lhs = lhs == nothing ? -SCIPinfinity(o) : lhs
-    rhs = rhs == nothing ?  SCIPinfinity(o) : rhs
+    lhs = lhs === nothing ? -SCIPinfinity(o) : lhs
+    rhs = rhs === nothing ?  SCIPinfinity(o) : rhs
 
     cr = add_linear_constraint(o.mscip, varrefs, coefs, lhs, rhs)
     ci = CI{SAF, S}(cr.val)
@@ -35,8 +35,8 @@ function MOI.set(o::SCIP.Optimizer, ::MOI.ConstraintSet, ci::CI{SAF,S}, set::S) 
     allow_modification(o)
 
     lhs, rhs = bounds(set)
-    lhs = lhs == nothing ? -SCIPinfinity(o) : lhs
-    rhs = rhs == nothing ?  SCIPinfinity(o) : rhs
+    lhs = lhs === nothing ? -SCIPinfinity(o) : lhs
+    rhs = rhs === nothing ?  SCIPinfinity(o) : rhs
 
     @SC SCIPchgLhsLinear(o, cons(o, ci), lhs)
     @SC SCIPchgRhsLinear(o, cons(o, ci), rhs)

--- a/src/MOI_wrapper/quadratic_constraints.jl
+++ b/src/MOI_wrapper/quadratic_constraints.jl
@@ -23,8 +23,8 @@ function MOI.add_constraint(o::Optimizer, func::SQF, set::S) where {S <: BOUNDS}
 
     # range
     lhs, rhs = bounds(set)
-    lhs = lhs == nothing ? -SCIPinfinity(o) : lhs
-    rhs = rhs == nothing ?  SCIPinfinity(o) : rhs
+    lhs = lhs === nothing ? -SCIPinfinity(o) : lhs
+    rhs = rhs === nothing ?  SCIPinfinity(o) : rhs
 
     cr = add_quadratic_constraint(o.mscip, linrefs, lincoefs,
                                   quadrefs1, quadrefs2, quadcoefs, lhs, rhs)
@@ -46,8 +46,8 @@ function MOI.set(o::SCIP.Optimizer, ::MOI.ConstraintSet, ci::CI{SQF,S}, set::S) 
     allow_modification(o)
 
     lhs, rhs = bounds(set)
-    lhs = lhs == nothing ? -SCIPinfinity(o) : lhs
-    rhs = rhs == nothing ?  SCIPinfinity(o) : rhs
+    lhs = lhs === nothing ? -SCIPinfinity(o) : lhs
+    rhs = rhs === nothing ?  SCIPinfinity(o) : rhs
 
     @SC SCIPchgLhsQuadratic(o, cons(o, ci), lhs)
     @SC SCIPchgRhsQuadratic(o, cons(o, ci), rhs)

--- a/src/MOI_wrapper/sepa.jl
+++ b/src/MOI_wrapper/sepa.jl
@@ -22,7 +22,7 @@ All parameters have default values, that can be set as keyword arguments.
 function include_sepa(o::Optimizer, sepa::SEPA;
                       name="", description="", priority=0, freq=1,
                       maxbounddist=0.0, usessubscip=false,
-                      delay=false) where SEPA <: AbstractSeparator
+                      delay=false) where {SEPA <: AbstractSeparator}
     include_sepa(o.mscip, sepa, name=name, description=description,
                  priority=priority, freq=freq, maxbounddist=maxbounddist,
                  usessubscip=usessubscip, delay=delay)
@@ -68,7 +68,7 @@ function MOI.get(o::Optimizer, ::MOI.CallbackVariablePrimal{CutCbData}, vi)
 end
 
 function MOI.set(o::Optimizer, ::MOI.UserCutCallback, cb::Function)
-    if o.moi_separator == Nothing
+    if o.moi_separator === nothing
         o.moi_separator = CutCbSeparator(o.mscip, cb)
         include_sepa(o, o.moi_separator)
     else
@@ -83,8 +83,8 @@ function MOI.submit(o::Optimizer, cb_data::MOI.UserCut{CutCbData},
     coefs = [t.coefficient for t in func.terms]
 
     lhs, rhs = bounds(set)
-    lhs = lhs == nothing ? -SCIPinfinity(o) : lhs
-    rhs = rhs == nothing ?  SCIPinfinity(o) : rhs
+    lhs = lhs === nothing ? -SCIPinfinity(o) : lhs
+    rhs = rhs === nothing ?  SCIPinfinity(o) : rhs
 
     add_cut_sepa(o.mscip, cb_data.callback_data.sepa, varrefs, coefs, lhs, rhs)
     cb_data.callback_data.submit_called = true

--- a/src/MOI_wrapper/variable.jl
+++ b/src/MOI_wrapper/variable.jl
@@ -116,8 +116,8 @@ function MOI.add_constraint(o::Optimizer, func::SVF, set::S) where S <: BOUNDS
     inf = SCIPinfinity(o)
 
     newlb, newub = bounds(set)
-    newlb = newlb == nothing ? -inf : newlb
-    newub = newub == nothing ?  inf : newub
+    newlb = newlb === nothing ? -inf : newlb
+    newub = newub === nothing ?  inf : newub
 
     # Check for existing bounds first.
     oldlb, oldub = SCIPvarGetLbOriginal(v), SCIPvarGetUbOriginal(v)
@@ -196,8 +196,8 @@ function MOI.set(o::SCIP.Optimizer, ::MOI.ConstraintSet, ci::CI{SVF,S}, set::S) 
     allow_modification(o)
     v = var(o, VI(ci.value)) # cons index is actually var index
     lb, ub = bounds(set)
-    lb = lb == nothing ? -SCIPinfinity(o) : lb
-    ub = ub == nothing ?  SCIPinfinity(o) : ub
+    lb = lb === nothing ? -SCIPinfinity(o) : lb
+    ub = ub === nothing ?  SCIPinfinity(o) : ub
     if SCIPvarGetType(v) == SCIP_VARTYPE_BINARY
         o.binbounds[vi] = MOI.Interval(lb, ub)
         lb = max(lb, 0.0)


### PR DESCRIPTION
The field for separators was set with a default "Nothing" instead of "nothing". This was adapted here.
Comparison with nothing is done with identity equality