### PR TITLE
Allow stage PRESOLVING in assert_solved

### DIFF
--- a/src/MOI_wrapper/results.jl
+++ b/src/MOI_wrapper/results.jl
@@ -51,14 +51,14 @@ end
 function assert_stage(o::Optimizer, stages)
     stage = SCIPgetStage(o)
     if !(stage in stages)
-        error("SCIP is wrong stage ($stage, need $stages), can not query results!")
+        error("SCIP is wrong stage ($stage, need $stages)!")
     end
 end
 
 "Make sure that the problem was solved (SCIP is in SOLVED stage)."
 function assert_solved(o::Optimizer)
     # SCIP's stage is SOLVING when stopped by user limit!
-    assert_stage(o, (SCIP_STAGE_SOLVING, SCIP_STAGE_SOLVED))
+    assert_stage(o, (SCIP_STAGE_PRESOLVING, SCIP_STAGE_SOLVING, SCIP_STAGE_SOLVED))
 
     # Check for invalid status (when stage is SOLVING).
     status = SCIPgetStatus(o)


### PR DESCRIPTION
This might happen if a user limit (ie time) stops the solver during presolving.

Fixes a bug [encountered](https://github.com/NREL-SIIP/PowerSimulations.jl/runs/4467002116?check_suite_focus=true#step:5:316) by @jd-lara.