### PR TITLE
Throw DeleteNotAllowed error when deleting variables

### DIFF
--- a/src/MOI_wrapper/variable.jl
+++ b/src/MOI_wrapper/variable.jl
@@ -28,7 +28,12 @@ function MOI.delete(o::Optimizer, vi::VI)
     # the variable-in-constraint relation, so, to be conservative, we only allow
     # to delete a variable when there are no constraints in the model.
     if length(o.inner.conss) > 0
-        error("Can not delete variable while model contains constraints!")
+        throw(
+            MOI.DeleteNotAllowed(
+                vi,
+                "Can not delete variable while model contains constraints!",
+            ),
+        )
     end
     allow_modification(o)
     if !haskey(o.inner.vars, VarRef(vi.value))

--- a/test/MOI_additional.jl
+++ b/test/MOI_additional.jl
@@ -129,7 +129,7 @@ end
     @test !MOI.is_empty(optimizer)
 
     # fail to delete them in wrong order
-    @test_throws ErrorException MOI.delete(optimizer, x)
+    @test_throws MOI.DeleteNotAllowed MOI.delete(optimizer, x)
 end
 
 @testset "set_parameter" begin

--- a/test/MOI_wrapper_cached.jl
+++ b/test/MOI_wrapper_cached.jl
@@ -1,46 +1,33 @@
 using MathOptInterface
 const MOI = MathOptInterface
-const MOIB = MOI.Bridges
-const MOIT = MOI.Test
-const MOIU = MOI.Utilities
 
-MOIU.@model(ModelData,
-            (),
-            (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval),
-            (MOI.SecondOrderCone,),
-            (MOI.SOS1, MOI.SOS2),
-            (),
-            (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
-            (MOI.VectorOfVariables,),
-            (MOI.VectorAffineFunction,))
-const CACHE = MOIU.UniversalFallback(ModelData{Float64}())
-const CACHED = MOIU.CachingOptimizer(CACHE, SCIP.Optimizer(display_verblevel=0))
-const BRIDGED2 = MOIB.full_bridge_optimizer(CACHED, Float64)
-
-const CONFIG_CACHED = MOIT.Config(
-    atol=5e-3, rtol=1e-4,
-    exclude=Any[
-        MOI.ConstraintDual, MOI.ConstraintName, MOI.DualObjectiveValue, MOI.VariableBasisStatus, MOI.ConstraintBasisStatus,
-    ],
-)
-
-@testset "MOI Modification tests" begin
-    exclude_list = copy(MOI_BASE_EXCLUDED)
-    append!(
-        exclude_list,
-        [
-            # Can not delete variable while model contains constraints
-            "test_basic_ScalarQuadraticFunction_ZeroOne",
-            "test_basic_VectorAffineFunction_NormOneCone",
-            "test_basic_VectorAffineFunction_SOS1",
-            "test_basic_VectorAffineFunction_SOS2",
-            "test_basic_VectorQuadraticFunction_NormOneCone",
-            "test_basic_VectorQuadraticFunction_SOS1",
-            "test_basic_VectorQuadraticFunction_SOS2",
-            "test_linear_integration",
-            "test_quadratic_duplicate_terms",
-            "test_quadratic_nonhomogeneous",
-        ]
+@testset "MOI_wrapper_cached" begin
+    MOI.Test.runtests(
+        MOI.Bridges.full_bridge_optimizer(
+            MOI.Utilities.CachingOptimizer(
+                MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+                SCIP.Optimizer(; display_verblevel = 0),
+            ),
+            Float64,
+        ),
+        MOI.Test.Config(
+            atol = 5e-3,
+            rtol = 1e-4,
+            exclude = Any[
+                MOI.ConstraintDual,
+                MOI.DualObjectiveValue,
+                MOI.VariableBasisStatus,
+                MOI.ConstraintBasisStatus,
+            ],
+        );
+        exclude = [
+            # Upstream problem in MOI.Test: InexactError: trunc(Int64, 1.0e20)
+            "test_cpsat_CountGreaterThan",
+            # SCIP does not support nonlinear objective functions.
+            "test_nonlinear_hs071_NLPBlockDual",
+            "test_nonlinear_invalid",
+            "test_nonlinear_objective",
+            "test_nonlinear_objective_and_moi_objective_test",
+        ],
     )
-    MOIT.runtests(BRIDGED2, CONFIG_CACHED, exclude = exclude_list)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,8 @@ const MOI_BASE_EXCLUDED = [
     "test_nonlinear_", # None of tests provide expression graphs in the evaluator.
     "ObjectiveFunction_ScalarAffineFunction", # requires conversion of objective function
     "test_objective_set_via_modify", # ListOfModelAttributesSet
+    # Upstream issue in MOI.Test
+    "test_cpsat_CountGreaterThan",
 ]
 
 @testset "MathOptInterface tests (direct)" begin


### PR DESCRIPTION
In addition, greatly simplify the MOI_wrapper_cached.jl file.

Thowing a `DeleteNotAllowed` will trigger the cache to rebuild the model. This means we can now run the full gamut of tests when using the cache. 

I don't know if there is value in running `_cached`, `_bridged`, and `_direct`. Perhaps we could delete the others? We really only care that the cache is working, and the number of excludes suggests that the rest of the API isn't fully implemented in direct mode.