### PR TITLE
Cache result of SCIPgetSols

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -114,7 +114,7 @@ function MOI.empty!(o::Optimizer)
     o.scip_solve_status = _kSCIP_SOLVE_STATUS_NOT_CALLED
     o.name_to_variable = nothing
     o.name_to_constraint_index = nothing
-    empty!(o.solution_storage)
+    o.solution_storage = Ptr{SCIP_SOL}[]
     return nothing
 end
 

--- a/src/MOI_wrapper/results.jl
+++ b/src/MOI_wrapper/results.jl
@@ -81,15 +81,13 @@ end
 function MOI.get(o::Optimizer, attr::MOI.ObjectiveValue)
     assert_solved(o)
     MOI.check_result_index_bounds(o, attr)
-    sols = unsafe_wrap(Array{Ptr{SCIP_SOL}}, SCIPgetSols(o), SCIPgetNSols(o))
-    return SCIPgetSolOrigObj(o, sols[attr.result_index])
+    return SCIPgetSolOrigObj(o, o.solution_storage[attr.result_index])
 end
 
 function MOI.get(o::Optimizer, attr::MOI.VariablePrimal, vi::MOI.VariableIndex)
     assert_solved(o)
     MOI.check_result_index_bounds(o, attr)
-    sols = unsafe_wrap(Array{Ptr{SCIP_SOL}}, SCIPgetSols(o), SCIPgetNSols(o))
-    return SCIPgetSolVal(o, sols[attr.result_index], var(o, vi))
+    return SCIPgetSolVal(o, o.solution_storage[attr.result_index], var(o, vi))
 end
 
 function MOI.get(
@@ -99,12 +97,8 @@ function MOI.get(
 )
     assert_solved(o)
     MOI.check_result_index_bounds(o, attr)
-    sols = unsafe_wrap(Array{Ptr{SCIP_SOL}}, SCIPgetSols(o), SCIPgetNSols(o))
-    return SCIPgetSolVal(
-        o,
-        sols[attr.result_index],
-        var(o, MOI.VariableIndex(ci.value)),
-    )
+    x = MOI.VariableIndex(ci.value)
+    return SCIPgetSolVal(o, o.solution_storage[attr.result_index], var(o, x))
 end
 
 function MOI.get(
@@ -114,8 +108,7 @@ function MOI.get(
 )
     assert_solved(o)
     MOI.check_result_index_bounds(o, attr)
-    sols = unsafe_wrap(Array{Ptr{SCIP_SOL}}, SCIPgetSols(o), SCIPgetNSols(o))
-    return SCIPgetActivityLinear(o, cons(o, ci), sols[attr.result_index])
+    return SCIPgetActivityLinear(o, cons(o, ci), o.solution_storage[attr.result_index])
 end
 
 function MOI.get(o::Optimizer, ::MOI.ObjectiveBound)

--- a/src/MOI_wrapper/results.jl
+++ b/src/MOI_wrapper/results.jl
@@ -108,7 +108,8 @@ function MOI.get(
 )
     assert_solved(o)
     MOI.check_result_index_bounds(o, attr)
-    return SCIPgetActivityLinear(o, cons(o, ci), o.solution_storage[attr.result_index])
+    sols = o.solution_storage[attr.result_index]
+    return SCIPgetActivityLinear(o, cons(o, ci), sols)
 end
 
 function MOI.get(o::Optimizer, ::MOI.ObjectiveBound)


### PR DESCRIPTION
instead of always refetching all solutions, creates and stores the vector once after solve