### PR TITLE
Fix return value of ListOfModelAttributesSet

### DIFF
--- a/src/MOI_wrapper/objective.jl
+++ b/src/MOI_wrapper/objective.jl
@@ -24,7 +24,7 @@ function MOI.set(o::Optimizer, ::MOI.ObjectiveFunction{SAF}, obj::SAF)
     end
 
     @SCIP_CALL SCIPaddOrigObjoffset(o, obj.constant - SCIPgetOrigObjoffset(o))
-
+    o.objective_function_set = true
     return nothing
 end
 
@@ -54,13 +54,14 @@ function MOI.set(o::Optimizer, ::MOI.ObjectiveSense, sense::MOI.OptimizationSens
 end
 
 function MOI.get(o::Optimizer, ::MOI.ObjectiveSense)
-    return o.objective_sense
+    return something(o.objective_sense, MOI.FEASIBILITY_SENSE)
 end
 
 function MOI.modify(o::Optimizer, ::MOI.ObjectiveFunction{SAF},
                     change::MOI.ScalarCoefficientChange{Float64})
     allow_modification(o)
     @SCIP_CALL SCIPchgVarObj(o, var(o, change.variable), change.new_coefficient)
+    o.objective_function_set = true
     return nothing
 end
 

--- a/test/MOI_wrapper_bridged.jl
+++ b/test/MOI_wrapper_bridged.jl
@@ -21,7 +21,6 @@ const CONFIG_BRIDGED = MOIT.Config(atol=5e-3, rtol=1e-4, exclude=Any[
         "test_basic_VectorQuadraticFunction_NormOneCone",
         "test_basic_VectorQuadraticFunction_SOS1",
         "test_basic_VectorQuadraticFunction_SOS2",
-        "test_model_ordered_indices", # TODO should fix? ListOf in order of creation
         "test_quadratic_duplicate_terms", # Can not delete variable while model contains constraints
         "test_quadratic_nonhomogeneous", # unsupported by bridge
         "ScalarAffineFunction_ZeroOne",
@@ -31,8 +30,6 @@ const CONFIG_BRIDGED = MOIT.Config(atol=5e-3, rtol=1e-4, exclude=Any[
         "test_basic_VectorQuadraticFunction_GeometricMeanCone",
         "test_basic_VectorAffineFunction_GeometricMeanCone",
         "test_variable_delete_SecondOrderCone",
-        "test_modification_func_scalaraffine_",
-        "test_modification_func_vectoraffine_",
         "test_linear_Indicator_ON_ZERO",
     ])
     MOIT.runtests(

--- a/test/MOI_wrapper_direct.jl
+++ b/test/MOI_wrapper_direct.jl
@@ -17,8 +17,6 @@ const CONFIG_DIRECT = MOIT.Config(
         "test_basic_VectorOfVariables_SecondOrderCone",
         "test_conic_SecondOrderCone_nonnegative_post_bound",
         "test_variable_delete_SecondOrderCone",
-        "test_modification_func_scalaraffine_",
-        "test_modification_func_vectoraffine_",
     ])
     MOIT.runtests(
         OPTIMIZER,


### PR DESCRIPTION
x-ref: https://github.com/jump-dev/MathOptInterface.jl/pull/2085

There are actually a bunch of excluded tests in SCIP. That's usually suggestive of bugs in the implementation.