### PR TITLE
Update SCIP.jl to support Ipopt precompiled with LBT

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,19 +7,20 @@ Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 SCIP_PaPILO_jll = "fc9abe76-a5e6-5fed-b0b7-a12f309cf031"
 SCIP_jll = "e5ac4fe4-a920-5659-9bf8-f9f73e9e79ce"
 
 [compat]
 MathOptInterface = "1"
+OpenBLAS32_jll = "0.3.10"
 SCIP_PaPILO_jll = "800"
 SCIP_jll = "800"
 julia = "1.6"
 
 [extras]
-OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "OpenBLAS32_jll", "Random"]
+test = ["Test", "Random"]

--- a/src/SCIP.jl
+++ b/src/SCIP.jl
@@ -1,8 +1,19 @@
 module SCIP
 
+import LinearAlgebra
+import OpenBLAS32_jll
+
+function __init__()
+    if VERSION >= v"1.9"
+        config = LinearAlgebra.BLAS.lbt_get_config()
+        if !any(lib -> lib.interface == :lp64, config.loaded_libs)
+            LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
+        end
+    end
+end
+
 # assorted utility functions
 include("util.jl")
-
 
 # load deps, version check
 include("init.jl")

--- a/src/SCIP.jl
+++ b/src/SCIP.jl
@@ -3,15 +3,6 @@ module SCIP
 import LinearAlgebra
 import OpenBLAS32_jll
 
-function __init__()
-    if VERSION >= v"1.9"
-        config = LinearAlgebra.BLAS.lbt_get_config()
-        if !any(lib -> lib.interface == :lp64, config.loaded_libs)
-            LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
-        end
-    end
-end
-
 # assorted utility functions
 include("util.jl")
 

--- a/src/init.jl
+++ b/src/init.jl
@@ -15,6 +15,12 @@ else
 end
 
 function __init__()
+    if VERSION >= v"1.9"
+        config = LinearAlgebra.BLAS.lbt_get_config()
+        if !any(lib -> lib.interface == :lp64, config.loaded_libs)
+            LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
+        end
+    end
     major = SCIPmajorVersion()
     minor = SCIPminorVersion()
     patch = SCIPtechVersion()


### PR DESCRIPTION
`SCIP_PaPILO_jll` is precompiled with an upper bound on `Ipopt_jll`. We can't download the last artifact of `Ipopt_jll` when we use Ipopt.jl if SCIP.jl is installed.
I updated SCIP.jl such that a BLAS / LAPACK backend is automatically loaded. You should be able to drop this [constraint](https://github.com/JuliaPackaging/Yggdrasil/blob/master/S/SCIP_PaPILO/build_tarballs.jl#L71) in the future.