### PR TITLE
Minimal changes to support SCIP 9

### DIFF
--- a/.github/workflows/MINLP.yml
+++ b/.github/workflows/MINLP.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['lts', '1']  # Test against current minor release (at least 1.3)
+        version: ['lts', '1']
         os: [ubuntu-latest, macOS-latest]
         arch: [x64]
     steps:

--- a/.github/workflows/MINLP.yml
+++ b/.github/workflows/MINLP.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1']  # Test against current minor release (at least 1.3)
+        version: ['lts', '1']  # Test against current minor release (at least 1.3)
         os: [ubuntu-latest, macOS-latest]
         arch: [x64]
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1']
+        version: ['lts', '1']
         os: [ubuntu-latest, macOS-latest]
         arch: [x64]
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,8 @@ SCIP_jll = "e5ac4fe4-a920-5659-9bf8-f9f73e9e79ce"
 [compat]
 MathOptInterface = "1.7"
 OpenBLAS32_jll = "0.3"
-SCIP_PaPILO_jll = "800"
-SCIP_jll = "800"
+SCIP_PaPILO_jll = "900"
+SCIP_jll = "900"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ MathOptInterface = "1.7"
 OpenBLAS32_jll = "0.3"
 SCIP_PaPILO_jll = "900"
 SCIP_jll = "900"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/init.jl
+++ b/src/init.jl
@@ -30,8 +30,8 @@ function __init__()
     minor = SCIPminorVersion()
     patch = SCIPtechVersion()
     current = VersionNumber("$major.$minor.$patch")
-    required = VersionNumber("8")
-    upperbound = VersionNumber("9")
+    required = VersionNumber("9")
+    upperbound = VersionNumber("10")
     if current < required || current >= upperbound
         @error(
             "SCIP is installed at version $current, " *


### PR DESCRIPTION
Minimal necessary changes to test with SCIP 9. All tests pass locally, but there seems to be an issue in CI with julia 1.6.

#286 