### PR TITLE
Persistence Of SCIPData Object

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -63,7 +63,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
             false,
             MOI.COMPUTE_CONFLICT_NOT_CALLED,
         )
-        finalizer(free_scip, o)
+        finalizer(free_scip, scip_data)
 
         # Set all parameters given as keyword arguments, replacing the
         # delimiter, since "/" is used by all SCIP parameters, but is not
@@ -76,6 +76,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     end
 end
 
+# [TODO] Should Be Safe To Remove
 free_scip(o::Optimizer) = free_scip(o.inner)
 
 Base.cconvert(::Type{Ptr{SCIP_}}, o::Optimizer) = o

--- a/test/conshdlr.jl
+++ b/test/conshdlr.jl
@@ -26,7 +26,7 @@
     @test ch.lock_called == 1
 
     # free the problem
-    finalize(o)
+    finalize(o.inner)
 end
 
 @testset "dummy conshdlr (always satisfied, with constraint)" begin
@@ -54,7 +54,7 @@ end
     @test ch.lock_called == 1
 
     # free the problem
-    finalize(o)
+    finalize(o.inner)
 end
 
 @testset "dummy conshdlr (always satisfied, no constraint, but needs it)" begin
@@ -79,7 +79,7 @@ end
     @test ch.lock_called == 0
 
     # free the problem
-    finalize(o)
+    finalize(o.inner)
 end
 
 @testset "never satisfied conshdlr (does not need constraint)" begin
@@ -104,7 +104,7 @@ end
     @test ch.lock_called == 1
 
     # free the problem
-    finalize(o)
+    finalize(o.inner)
 end
 
 @testset "never satisfied conshdlr (needs constraint but does not have it)" begin
@@ -129,7 +129,7 @@ end
     @test ch.lock_called == 0
 
     # free the problem
-    finalize(o)
+    finalize(o.inner)
 end
 
 @testset "never satisfied conshdlr (needs constraint and has one)" begin
@@ -157,5 +157,5 @@ end
     @test ch.lock_called == 1
 
     # free the problem
-    finalize(o)
+    finalize(o.inner)
 end

--- a/test/scip_data.jl
+++ b/test/scip_data.jl
@@ -27,7 +27,7 @@ end
 @testset "create and semi-manual free" begin
     o = SCIP.Optimizer()
     @test o.inner.scip[] != C_NULL
-    finalize(o)
+    finalize(o.inner)
     @test o.inner.scip[] == C_NULL
 end
 
@@ -77,7 +77,7 @@ end
             SCIP.@SCIP_CALL SCIP.SCIPsolve(o.inner.scip[])
         end
 
-        finalize(o)
+        finalize(o.inner)
         for var in values(o.inner.vars)
             @test var[] == C_NULL
         end
@@ -108,7 +108,7 @@ end
             SCIP.@SCIP_CALL SCIP.SCIPsolve(o)
         end
 
-        finalize(o)
+        finalize(o.inner)
         for var in values(o.inner.vars)
             @test var[] == C_NULL
         end


### PR DESCRIPTION
This fix an issue with garbage collection when only the inner object of the optimizer is used as exemplified by the following example
```julia
import SCIP

function make_optimizer()
    optimizer = SCIP.Optimizer()
    return optimizer.inner
end

function run_test1()
    scip_data = make_optimizer()
    GC.gc(true)
    @assert(scip_data.scip[] != C_NULL)
end

function run_test2()
    scip_data = SCIP.Optimizer()
    inner = scip_data.inner
    scip_data = 0
    GC.gc(true)
    @assert(inner.scip[] != C_NULL)
end

GC.enable_logging(true)

# Both test should fail before fix
run_test1()
run_test2()
```

The fix is to change the finalizer call to listen to garbage collection events for the SCIPdata object of the MOI Optimizer object instead of listen to garbage collection events for the whole MOI Optimizer object