### PR TITLE
Fix Issue With Garbage Collection

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -316,6 +316,8 @@ function MOI.empty!(o::Optimizer)
     o.conflict_status = MOI.COMPUTE_CONFLICT_NOT_CALLED
     o.moi_separator = nothing
     o.moi_heuristic = nothing
+    finalizer(free_scip, o.inner)
+
     return nothing
 end
 


### PR DESCRIPTION
This fix the issue mentioned in https://github.com/scipopt/SCIP.jl/issues/296.

When creating a model using JuMP, i.e. via `model = Model(SCIP.Optimizer)`. JuMP creates a model with Caching + Constraint Bridge activated. The way this works is during the `optimize!` call JuMP will call the `MOI.empty!` function which first delete the existing SCIPData object, creates a new on, then reinput all the problem in one go. This means that the SCIPData that was created during the `Model(SCIP.Optimizer)` call and the one that is used during the optimization process may differ. 

In the pull request https://github.com/scipopt/SCIP.jl/pull/290, the finalizer was only added to the SCIPData created during the `Model` call. Now the finalizer call is also added to the SCIPData object created during the `MOI.empty!` call.