### PR TITLE
Fix type stability of Base.RefValue fields

### DIFF
--- a/src/nonlinear.jl
+++ b/src/nonlinear.jl
@@ -31,7 +31,7 @@ Returns the SCIP expression pointer, whether the expression is a pure value (wit
 function push_expr!(
     nonlin::NonlinExpr,
     scip::Ptr{SCIP_},
-    vars::Dict{VarRef,Ref{Ptr{SCIP_VAR}}},
+    vars::Dict{VarRef,<:Ref{Ptr{SCIP_VAR}}},
     expr::Expr,
 )
     # Storage for SCIP_EXPR*
@@ -262,7 +262,7 @@ end
 function push_expr!(
     nonlin::NonlinExpr,
     scip::Ptr{SCIP_},
-    vars::Dict{VarRef,Ref{Ptr{SCIP_VAR}}},
+    vars::Dict{VarRef,<:Ref{Ptr{SCIP_VAR}}},
     expr::Number,
 )
     # Storage for SCIP_EXPR*

--- a/src/scip_data.jl
+++ b/src/scip_data.jl
@@ -31,9 +31,9 @@ SCIPData holds pointers to SCIP data.
 It does not perform memory management and should not be created directly.
 """
 mutable struct SCIPData
-    scip::Ref{Ptr{SCIP_}}
-    vars::Dict{VarRef,Ref{Ptr{SCIP_VAR}}}
-    conss::Dict{ConsRef,Ref{Ptr{SCIP_CONS}}}
+    scip::Base.RefValue{Ptr{SCIP_}}
+    vars::Dict{VarRef,Base.RefValue{Ptr{SCIP_VAR}}}
+    conss::Dict{ConsRef,Base.RefValue{Ptr{SCIP_CONS}}}
 
     var_count::Int64
     cons_count::Int64
@@ -69,8 +69,8 @@ mutable struct SCIPData
         @SCIP_CALL SCIPcreateProbBasic(scip[], "")
         scip_data = new(
             scip,
-            Dict{VarRef,Ref{Ptr{SCIP_VAR}}}(),
-            Dict{ConsRef,Ref{Ptr{SCIP_CONS}}}(),
+            Dict{VarRef,Base.RefValue{Ptr{SCIP_VAR}}}(),
+            Dict{ConsRef,Base.RefValue{Ptr{SCIP_CONS}}}(),
             0,
             0,
             Dict{Any,Ptr{SCIP_CONSHDLR}}(),

--- a/src/sepa.jl
+++ b/src/sepa.jl
@@ -215,7 +215,7 @@ associated to the separator `sepa`.
 """
 function add_cut_sepa(
     scip::Ptr{SCIP_},
-    vars::Dict{VarRef,Ref{Ptr{SCIP_VAR}}},
+    vars::Dict{VarRef,<:Ref{Ptr{SCIP_VAR}}},
     sepas::Dict{Any,Ptr{SCIP_SEPA}},
     sepa::SEPA,
     varrefs,


### PR DESCRIPTION
I was trying to figure out why https://github.com/scipopt/SCIP.jl/pull/241 was needed. Benchmarking showed some allocations that I didn't expect. Then I found that `unsafe_convert` was typed as `::Any`!

```julia
julia> import SCIP

julia> import MathOptInterface as MOI

julia> model = SCIP.Optimizer();

julia> @time SCIP.SCIPgetSols(model)
  0.000005 seconds (2 allocations: 32 bytes)
Ptr{Ptr{Nothing}} @0x0000000000000000

julia> @time SCIP.SCIPgetNSols(model)
  0.000007 seconds (1 allocation: 16 bytes)
0

julia> @code_warntype SCIP.SCIPgetNSols(model)
MethodInstance for SCIP.LibSCIP.SCIPgetNSols(::SCIP.Optimizer)
  from SCIPgetNSols(scip) @ SCIP.LibSCIP ~/.julia/packages/SCIP/9Wf6c/src/LibSCIP.jl:18286
Arguments
  #self#::Core.Const(SCIP.LibSCIP.SCIPgetNSols)
  scip::SCIP.Optimizer
Body::Int32
1 ─ %1 = Core.apply_type(SCIP.LibSCIP.Ptr, SCIP.LibSCIP.SCIP)::Core.Const(Ptr{Nothing})
│   %2 = Base.cconvert(%1, scip)::SCIP.Optimizer
│   %3 = Core.apply_type(SCIP.LibSCIP.Ptr, SCIP.LibSCIP.SCIP)::Core.Const(Ptr{Nothing})
│   %4 = Base.unsafe_convert(%3, %2)::Any
│   %5 = $(Expr(:foreigncall, :(Core.tuple(:SCIPgetNSols, SCIP.LibSCIP.libscip)), Int32, svec(Ptr{Nothing}), 0, :(:ccall), :(%4), :(%2)))::Int32
└──      return %5
```

It's because of this classic gag that `Base.Ref{T}` is not a concrete value:
```julia
julia> x = Ref{Cint}(1)
Base.RefValue{Int32}(1)

julia> typeof(x)
Base.RefValue{Int32}

julia> typeof(x) <: Ref{Cint}
true
```

The fix is a couple of uses of `Base.RefValue`:

```Julia
julia> import SCIP

julia> import MathOptInterface as MOI

julia> model = SCIP.Optimizer();

julia> @time SCIP.SCIPgetSols(model)
  0.000008 seconds (1 allocation: 16 bytes)
Ptr{Ptr{Nothing}} @0x0000000000000000

julia> @time SCIP.SCIPgetNSols(model)
  0.000005 seconds
0

julia> @code_warntype SCIP.SCIPgetNSols(model)
MethodInstance for SCIP.LibSCIP.SCIPgetNSols(::SCIP.Optimizer)
  from SCIPgetNSols(scip) @ SCIP.LibSCIP ~/.julia/dev/SCIP/src/LibSCIP.jl:18291
Arguments
  #self#::Core.Const(SCIP.LibSCIP.SCIPgetNSols)
  scip::SCIP.Optimizer
Body::Int32
1 ─ %1 = Core.apply_type(SCIP.LibSCIP.Ptr, SCIP.LibSCIP.SCIP)::Core.Const(Ptr{Nothing})
│   %2 = Base.cconvert(%1, scip)::SCIP.Optimizer
│   %3 = Core.apply_type(SCIP.LibSCIP.Ptr, SCIP.LibSCIP.SCIP)::Core.Const(Ptr{Nothing})
│   %4 = Base.unsafe_convert(%3, %2)::Ptr{Nothing}
│   %5 = $(Expr(:foreigncall, :(Core.tuple(:SCIPgetNSols, SCIP.LibSCIP.libscip)), Int32, svec(Ptr{Nothing}), 0, :(:ccall), :(%4), :(%2)))::Int32
└──      return %5
```